### PR TITLE
fix!: Enhance window closing with graceful and forceful options

### DIFF
--- a/gnome_windows_client.py
+++ b/gnome_windows_client.py
@@ -125,8 +125,8 @@ class GnomeWindowsExtensionClient:
     def activate(self, winid: int):
         self.interface.Activate(winid)
 
-    def close(self, winid: int):
-        self.interface.Close(winid)
+    def close(self, winid: int, isForced=False):
+        self.interface.Close(winid, isForced)
 
     # Composite actions
     def get_focused_window_id(self) -> Optional[int]:

--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ MonitorMove = Tuple[Literal["monitor-move"], WorkspaceAndMonitorDirection]
 MaximizeAction = Tuple[Literal["maximize"]]
 UnmaximizeAction = Tuple[Literal["unmaximize"]]
 MinimizeAction = Tuple[Literal["minimize"]]
-CloseAction = Tuple[Literal["close"]]
+CloseAction = Tuple[Literal["close"], bool]
 
 WindowAction = Union[
     PlaceAction,
@@ -151,7 +151,8 @@ def WindowManagerAction(action):
         "maximize": ("maximize",),
         "unmaximize": ("unmaximize",),
         "minimize": ("minimize",),
-        "close": ("close",),
+        "close": ("close", False),
+        "force-close": ("close", True),
     }
 
     if action in window_manager_actions:
@@ -183,7 +184,8 @@ def WindowManagerAction(action):
             case "minimize":
                 client.minimize(focused_window_id)
             case "close":
-                client.close(focused_window_id)
+                _, is_forced = selected_action
+                client.close(focused_window_id, is_forced)
 
 
 if __name__ == "__main__":

--- a/manifest.json
+++ b/manifest.json
@@ -144,6 +144,13 @@
       "name": "Close",
       "default_value": "Close",
       "description": "Close focused application"
+    },
+    {
+      "id": "force-close",
+      "type": "keyword",
+      "name": "Force Close",
+      "default_value": "Force Close",
+      "description": "Forcefully close focused application"
     }
   ]
 }


### PR DESCRIPTION
Align with version 5 of window-commander.

BREAKING CHANGE: The Close action now performs a gracefull shutdown of the focused application. A new action called Force Close can be used to forcefully close/kill the focused application.