### PR TITLE
Fix typo in manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,7 @@
       "type": "keyword",
       "name": "Left Half",
       "default_value": "Left Half",
-      "description": "Moe focused window to the left half of the screen"
+      "description": "Move focused window to the left half of the screen"
     },
     {
       "id": "right-half",


### PR DESCRIPTION
This pull request includes a small correction to the `manifest.json` file. The change fixes a typo in the description of the "Left Half" keyword, replacing "Moe" with "Move" for clarity.